### PR TITLE
FEATURE: Support objects that implement __toString in string propType

### DIFF
--- a/Classes/Validators/PropTypeValidator.php
+++ b/Classes/Validators/PropTypeValidator.php
@@ -5,7 +5,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Validation\Validator\ConjunctionValidator;
 use Neos\Flow\Validation\Validator\DisjunctionValidator;
-use Neos\Flow\Validation\Validator\StringValidator;
 use Neos\Flow\Validation\Validator\RegularExpressionValidator;
 use Neos\Flow\Validation\Validator\NotEmptyValidator;
 use Neos\Flow\Validation\Validator\ValidatorInterface;

--- a/Classes/Validators/StringValidator.php
+++ b/Classes/Validators/StringValidator.php
@@ -1,0 +1,27 @@
+<?php
+namespace PackageFactory\AtomicFusion\PropTypes\Validators;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Validation\Validator\AbstractValidator;
+
+/**
+ * Validator for strings.
+ */
+class StringValidator extends AbstractValidator
+{
+    protected $acceptsEmptyValues = false;
+
+    /**
+     * Checks if the given value is a string or an object that implements __toString.
+     *
+     * @param mixed $value The value that should be validated
+     * @return void
+     */
+    protected function isValid($value)
+    {
+        if (is_null($value) || is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            return;
+        }
+        $this->addError('A string or an object implementing __toString is expected.', 1617809129);
+    }
+}

--- a/Tests/Unit/Validators/StringValidatorTest.php
+++ b/Tests/Unit/Validators/StringValidatorTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace PackageFactory\AtomicFusion\PropTypes\Tests\Unit\Validators;
+
+use Neos\Flow\Tests\Unit\Validation\Validator\AbstractValidatorTestcase;
+use PackageFactory\AtomicFusion\PropTypes\Validators\BooleanValidator;
+use PackageFactory\AtomicFusion\PropTypes\Validators\StringValidator;
+
+/**
+ * Testcase for the boolean validator
+ *
+ */
+class StringValidatorTest extends AbstractValidatorTestcase
+{
+    protected $validatorClassName = StringValidator::class;
+
+    /**
+     * Data provider with valid examples
+     *
+     * @return array
+     */
+    public function validExamples()
+    {
+
+        return [
+            [null],
+            [""],
+            ["hello world"],
+            [new class() {
+                public function __toString()
+                {
+                    return "hello world";
+                }
+            }]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider validExamples
+     */
+    public function validatorReturnsNoErrorsForValidExamples($value)
+    {
+        $this->assertFalse($this->validator->validate($value)->hasErrors());
+    }
+
+    /**
+     * Data provider with invalid examples
+     *
+     * @return array
+     */
+    public function invalidExamples()
+    {
+        return [
+            [123],
+            [false],
+            [true],
+            [[]],
+            [[1,2,3]],
+            [new class() {}]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidExamples
+     */
+    public function validatorReturnsErrorsForInValidExamples($value)
+    {
+        $this->assertTrue($this->validator->validate($value)->hasErrors());
+    }
+}


### PR DESCRIPTION
This change replaces the default flow string validator that only accepts null or strings with a custom one that will also accept objects that implement __toString.

Among other things this will be allowed by this:
- i18nTokens without calling translate in the end 
- kaleidoscopeImageSources can be passed to string properties ... and will render as uri

Resolves. #13 