### PR TITLE
FEATURE: PropTypeValidationAspect executes for child classes of ComponentImplementation

### DIFF
--- a/Classes/Aspects/PropTypeValidationAspect.php
+++ b/Classes/Aspects/PropTypeValidationAspect.php
@@ -16,7 +16,7 @@ use Neos\Utility\ObjectAccess;
 class PropTypeValidationAspect
 {
     /**
-     * @Flow\Around("setting(PackageFactory.AtomicFusion.PropTypes.enable) && method(Neos\Fusion\FusionObjects\ComponentImplementation->getProps())")
+     * @Flow\Around("setting(PackageFactory.AtomicFusion.PropTypes.enable) && within(Neos\Fusion\FusionObjects\ComponentImplementation) && method(.*->getProps())")
      * @param JoinPointInterface $joinPoint The current join point
      * @return mixed
      */


### PR DESCRIPTION
We have a case, where we have a custom implementation of getProps() which inherits from `Neos\Fusion\FusionObjects\ComponentImplementation`, but currently the Aspect doesn't match our child class.

With this PR the aspect also run's on child classes of the ContentImplementation.