### PR TITLE
Feature: Inline-docs in EEL Helper instead of `__call`

### DIFF
--- a/Classes/Eel/PropTypesHelper.php
+++ b/Classes/Eel/PropTypesHelper.php
@@ -1,35 +1,186 @@
 <?php
 namespace PackageFactory\AtomicFusion\PropTypes\Eel;
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Validation\Validator\ValidatorInterface;
 use PackageFactory\AtomicFusion\PropTypes\Validators\PropTypeValidator;
 
+/**
+ * Factory for the `@propType` validators of your Fusion components.
+ *
+ * ```
+ * prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
+ *   \@propTypes {
+ *     # optional, enforce that only validated props exist
+ *     \@strict = true
+ *     # validation rules for props
+ *     title = ${PropTypes.string.isRequired}
+ *     subtitle = ${PropTypes.string}
+ *     color = ${PropTypes.oneOf(["red", "marcherry"])}
+ *   }
+ * }
+ * ```
+ *
+ * Each method will create a new validator.
+ * To make a value mandatory you can use the `isRequired` property of the validator.
+ *
+ * @example PropTypes.oneOf([123, "foo"]).isRequired
+ *
+ * Note on properties like `isRequired`, `boolean` or `string`
+ * Those are not actual properties but implemented as getters like `getString`.
+ * Eel will make sure to call the appropriate getter.
+ */
 class PropTypesHelper implements ProtectedContextAwareInterface
 {
     /**
-     * Create a fresh instance of the PropTypeValidator and call the first method
+     * Accepts any value including null.
      *
-     * @param $methodName
-     * @param $arguments
-     * @return PropTypeValidator
+     * @example PropTypes.any
      */
-    public function __call($methodName, $arguments)
+    public function getAny(): PropTypeValidator
     {
-        $validator = new PropTypeValidator();
-        if (in_array($methodName, PropTypeValidator::VALID_EEL_METHODS)) {
-            return $validator->{$methodName}(...$arguments);
-        } else {
-            throw new \Exception('This is not supported');
-        }
+        return (new PropTypeValidator())->getAny();
     }
 
     /**
-     * @param string $methodName
-     * @return bool
+     * Validate that a boolean value is given, accepts null.
+     *
+     * @example PropTypes.boolean
      */
+    public function getBoolean(): PropTypeValidator
+    {
+        return (new PropTypeValidator())->getBoolean();
+    }
+
+    /**
+     * Validate that an integer is given, accepts null.
+     *
+     * @example PropTypes.integer
+     */
+    public function getInteger(): PropTypeValidator
+    {
+        return (new PropTypeValidator())->getInteger();
+    }
+
+    /**
+     * Validate that an float is given, accepts null.
+     *
+     * @example PropTypes.float
+     */
+    public function getFloat(): PropTypeValidator
+    {
+        return (new PropTypeValidator())->getFloat();
+    }
+
+    /**
+     * Validate that an string is given, accepts null.
+     *
+     * @example PropTypes.string
+     */
+    public function getString(): PropTypeValidator
+    {
+        return (new PropTypeValidator())->getString();
+    }
+
+    /**
+     * Validate that the given string matches the pattern
+     *
+     * @example PropTypes.arrayOf(PropTypes.string)
+     *
+     * @param string $regularExpression
+     */
+    public function regex($regularExpression): PropTypeValidator
+    {
+        return (new PropTypeValidator())->regex($regularExpression);
+    }
+
+    /**
+     * Validate the value equals one of the given options.
+     *
+     * @example PropTypes.oneOf([123, "foo", "bar"])
+     *
+     * @param mixed[] $values
+     */
+    public function oneOf(array $values): PropTypeValidator
+    {
+        return (new PropTypeValidator())->oneOf($values);
+    }
+
+    /**
+     * Validate an array was given and all validate with the given validator, accepts null.
+     *
+     * @example PropTypes.arrayOf(PropTypes.string)
+     */
+    public function arrayOf(ValidatorInterface $itemValidator): PropTypeValidator
+    {
+        return (new PropTypeValidator())->arrayOf($itemValidator);
+    }
+
+    /**
+     * Validate the value validates at least with one of the given validators, accepts null.
+     *
+     * @example PropTypes.anyOf( PropTypes.string, PropTypes.integer )
+     */
+    public function anyOf(ValidatorInterface ...$validators): PropTypeValidator
+    {
+        return (new PropTypeValidator())->anyOf(...$validators);
+    }
+
+    /**
+     * Validate the keys of the given array validate with the assigned Validator, accepts null and ignores all other keys.
+     *
+     * The key validators have to define wether a single key is required.
+     *
+     * alias for @see shape
+     *
+     * @example PropTypes.dataStructure({'foo': PropTypes.integer, 'bar': PropTypes.string})
+     *
+     * @param array $shape
+     */
+    public function dataStructure($shape): PropTypeValidator
+    {
+        return (new PropTypeValidator())->dataStructure($shape);
+    }
+
+    /**
+     * Validate the keys of the given array validate with the assigned Validator, accepts null and ignores all other keys.
+     * The key validators have to define wether a single key is required.
+     *
+     * alias for @see dataStructure
+     *
+     * @example PropTypes.shape({'foo': PropTypes.integer, 'bar': PropTypes.string})
+     *
+     * @param array $shape
+     */
+    public function shape($shape): PropTypeValidator
+    {
+        return (new PropTypeValidator())->shape($shape);
+    }
+
+    /**
+     * Validate that a given value is an existing file.
+     *
+     * @example PropTypes.fileExists
+     */
+    public function getFileExists(): PropTypeValidator
+    {
+        return (new PropTypeValidator())->getFileExists();
+    }
+
+    /**
+     * Validate the value with the given type, if the value is a Node the NodeType is checked instead of the php-class, accepts null.
+     *
+     * @example PropTypes.instanceOf('Neos.Neos:Document')
+     *
+     * @param string $type
+     */
+    public function instanceOf($type): PropTypeValidator
+    {
+        return (new PropTypeValidator())->instanceOf($type);
+    }
+
     public function allowsCallOfMethod($methodName)
     {
-        return in_array($methodName, PropTypeValidator::VALID_EEL_METHODS);
+        return true;
     }
 }

--- a/Classes/Validators/PropTypeValidator.php
+++ b/Classes/Validators/PropTypeValidator.php
@@ -12,24 +12,6 @@ use Neos\Flow\Validation\Validator\ValidatorInterface;
 
 class PropTypeValidator extends ConjunctionValidator implements ProtectedContextAwareInterface
 {
-
-    const VALID_EEL_METHODS = [
-        'getAny',
-        'getString',
-        'getBoolean',
-        'getInteger',
-        'getFloat',
-        'getNumber',
-        'getFileExists',
-        'instanceOf',
-        'regex',
-        'arrayOf',
-        'shape',
-        'dataStructure',
-        'anyOf',
-        'oneOf'
-    ];
-
     /**
      * @var ConjunctionValidator
      * @Flow\Inject

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,4 +6,4 @@ PackageFactory:
 Neos:
   Fusion:
     defaultContext:
-      PropTypes: \PackageFactory\AtomicFusion\PropTypes\Eel\PropTypesHelper
+      PropTypes: PackageFactory\AtomicFusion\PropTypes\Eel\PropTypesHelper

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ via.
 * `PropTypes.arrayOf( PropTypes.string )`:
    Validate an array was given and all validate with the given validator, accepts null.
 * `PropTypes.anyOf( PropTypes.string, PropTypes.integer )`:
-   Validate the value validates at least with one of the given validators, accepts null..
+   Validate the value validates at least with one of the given validators, accepts null.
 * `PropTypes.dataStructure({'foo': PropTypes.integer, 'bar': PropTypes.string})`:
    Validate the keys of the given array validate with the assigned Validator,
    accepts null and ignores all other keys. The key validators have to define wether a single key is required.


### PR DESCRIPTION

This will allow IDEs to better help you write these PropTypes:


https://user-images.githubusercontent.com/85400359/197967665-9bdc1382-c750-482c-b0d3-473672af598a.mp4

(credit: https://marketplace.visualstudio.com/items?itemName=SimonSchmidt.vscode-neos-fusion-lsp)