### PR TITLE
BUGFIX: Handle ArrayAccess in DataStructure validator gracefully

### DIFF
--- a/Classes/Validators/DataStructureValidator.php
+++ b/Classes/Validators/DataStructureValidator.php
@@ -37,11 +37,7 @@ class DataStructureValidator extends AbstractValidator
             $result = $this->getResult() ?: new Result();
             foreach ($this->options['dataStructure'] as $key => $subValidator) {
                 if (is_array($value) || ($value instanceof \ArrayAccess)) {
-                    if (array_key_exists($key, $value)) {
-                        $subValue = $value[$key];
-                    } else {
-                        $subValue = null;
-                    }
+                    $subValue = $value[$key] ?? null;
                 } elseif (ObjectAccess::isPropertyGettable($value, $key)) {
                     $subValue = ObjectAccess::getPropertyPath($value, $key);
                 } else {

--- a/Classes/Validators/ShapeValidator.php
+++ b/Classes/Validators/ShapeValidator.php
@@ -37,11 +37,7 @@ class ShapeValidator extends AbstractValidator
             $result = $this->getResult() ?: new Result();
             foreach ($this->options['shape'] as $key => $subValidator) {
                 if (is_array($value) || ($value instanceof \ArrayAccess)) {
-                    if (array_key_exists($key, $value)) {
-                        $subValue = $value[$key];
-                    } else {
-                        $subValue = null;
-                    }
+                    $subValue = $value[$key] ?? null;
                 } elseif (ObjectAccess::isPropertyGettable($value, $key)) {
                     $subValue = ObjectAccess::getPropertyPath($value, $key);
                 } else {


### PR DESCRIPTION
While the data structure validator accepted array access it threw errors when an object actually used this because array_key_exists does not allow passing arrays.